### PR TITLE
adds option to mount a dirctory for volume mounts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,18 +3,9 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 max_line_length = 120
-tab_width = 4
-
-[{*.bash,*.sh,*.zsh}]
-indent_size = 2
 tab_width = 2
 
-[{*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.stylelintrc,bowerrc,jest.config}]
-indent_size = 2
-
-[{*.yaml,*.yml}]
-indent_size = 2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,13 @@ Vagrant.configure("2") do |config|
     vb.memory = "1024"
   end
 
+  podmanWorkingDir=ENV['PODMAN_WORKING_DIR']
+  if podmanWorkingDir != nil && podmanWorkingDir != ""
+    config.vm.synced_folder podmanWorkingDir, podmanWorkingDir,
+      owner: "root",
+      group: "root"
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
     yum install -y podman
 

--- a/scripts/mountpoint-handler.sh
+++ b/scripts/mountpoint-handler.sh
@@ -1,0 +1,25 @@
+export PODMAN_WORKING_DIR=
+
+podmanMountFile="$VAGRANT_CWD/mounted"
+
+set_podman_working_dir() {
+  if [[ -d "$1" ]]; then
+    echo "$1" > "$podmanMountFile"
+    PODMAN_WORKING_DIR="$1"
+  else
+    echo "$1 is not a directory"
+    exit 1
+  fi
+}
+
+read_podman_working_dir() {
+  if [[ -e "$podmanMountFile" ]]; then
+    PODMAN_WORKING_DIR=$(cat "$podmanMountFile")
+  fi
+}
+
+remove_mount_file() {
+  if [[ -e "$podmanMountFile" ]]; then
+    rm "$podmanMountFile"
+  fi
+}

--- a/scripts/podman-start
+++ b/scripts/podman-start
@@ -1,6 +1,65 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
 export VAGRANT_CWD=__VAR__TOOLS__DIR__
 
-echo "Starting podman"
-vagrant up
+vagrantCommand="vagrant up"
+
+script_dir=
+script_dir=$(dirname -- "$(readlink -e "${BASH_SOURCE[0]}" || realpath "${BASH_SOURCE[0]}")")
+source "$script_dir/mountpoint-handler.sh"
+
+main() {
+  read_parameters "$@"
+
+  echo "Starting podman"
+  eval "$vagrantCommand"
+}
+
+show_help() {
+  cat << EOF
+  Usage: $(basename "$0") <options>
+      -h, --help                  Display help
+      -v, --verbose               Display verbose output
+      -c, --current-working-dir   Mount the current working directory
+      -d, --directory             Mount a custom directory
+EOF
+}
+
+read_parameters() {
+  while :; do
+    case "${1:-}" in
+      -h|--help)
+        show_help
+        exit
+        ;;
+      -v|--verbose)
+        set -x
+        ;;
+      -c|--current-working-dir)
+        set_podman_working_dir "$(pwd)"
+        ;;
+      -d|--directory)
+        if [[ -n "${2:-}" ]]; then
+          set_podman_working_dir "$2"
+          shift
+        else
+          echo "ERROR: parameter '-d|--directory' cannot be empty." >&2
+          exit 1
+        fi
+        ;;
+      *)
+        if [[ "$*" != "" ]]; then
+          vagrantCommand="$vagrantCommand $*"
+        fi
+        break
+        ;;
+    esac
+
+    shift
+  done
+}
+
+main "$@"

--- a/scripts/podman-stop
+++ b/scripts/podman-stop
@@ -1,6 +1,57 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
 export VAGRANT_CWD=__VAR__TOOLS__DIR__
 
-echo "Stopping podman"
-vagrant halt
+vagrantCommand="vagrant halt"
+
+script_dir=
+script_dir=$(dirname -- "$(readlink -e "${BASH_SOURCE[0]}" || realpath "${BASH_SOURCE[0]}")")
+source "$script_dir/mountpoint-handler.sh"
+
+
+main() {
+  read_parameters "$@"
+  read_podman_working_dir
+
+  echo "Stopping podman"
+  eval "$vagrantCommand"
+}
+
+show_help() {
+  cat << EOF
+  Usage: $(basename "$0") <options>
+      -h, --help        Display help
+      -v, --verbose     Display verbose output
+      -d, --destroy     Runs 'vagrant destroy' (default is 'vagrant halt')
+EOF
+}
+
+read_parameters() {
+  while :; do
+    case "${1:-}" in
+      -h|--help)
+        show_help
+        exit
+        ;;
+      -v|--verbose)
+        set -x
+        ;;
+      -d|--destroy)
+        vagrantCommand="vagrant destroy -f"
+        ;;
+      *)
+        if [[ "$*" != "" ]]; then
+          vagrantCommand="$vagrantCommand $*"
+        fi
+        break
+        ;;
+    esac
+
+    shift
+  done
+}
+
+main "$@"

--- a/scripts/podman-stop
+++ b/scripts/podman-stop
@@ -17,7 +17,7 @@ main() {
   read_podman_working_dir
 
   echo "Stopping podman"
-  eval "$vagrantCommand"
+  eval "$vagrantCommand" && remove_mount_file
 }
 
 show_help() {


### PR DESCRIPTION
This PR adds an option to mount the current working directory or any other directory to the vagrant box at startup while preserving the directory structure.

After starting the vagrant box using `podman-start -c` you can run `podman run --rm -i -t -v $(pwd):/volume/mounted --security-opt label=disable alpine sh` and test the volume in your container.

The security-opt (`security-opt label=disable`) is required as fedora has SELinux enabled.